### PR TITLE
Correct case for Linux

### DIFF
--- a/SafeMCP23017.h
+++ b/SafeMCP23017.h
@@ -8,7 +8,7 @@
 #ifndef LIBRARIES_UPS_SAFEMCP23017_H_
 #define LIBRARIES_UPS_SAFEMCP23017_H_
 
-#include <arduino.h>
+#include <Arduino.h>
 #include <Adafruit_MCP23017.h>
 
 class SafeMCP23017 {

--- a/UPS.h
+++ b/UPS.h
@@ -8,7 +8,7 @@
 #ifndef LIBRARIES_UPS_UPS_H_
 #define LIBRARIES_UPS_UPS_H_
 
-#include <arduino.h>
+#include <Arduino.h>
 #include <SafeMCP23017.h>
 #include <USBRating.h>
 


### PR DESCRIPTION
Linux is case sensitive, needs "Arduino.h" instead of "arduino.h"